### PR TITLE
Fix: Release dynamically allocated memory.

### DIFF
--- a/lib/tcprelay.cpp
+++ b/lib/tcprelay.cpp
@@ -86,15 +86,23 @@ TcpRelay::TcpRelay(QTcpSocket *localSocket,
     remote->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
 }
 
+TcpRelay::~TcpRelay()
+{
+	encryptor->deleteLater();
+	timer->deleteLater();
+	remote->deleteLater();
+	local->deleteLater();
+}
+
 void TcpRelay::close()
 {
     if (stage == DESTROYED) {
         return;
     }
 
+    stage = DESTROYED;
     local->close();
     remote->close();
-    stage = DESTROYED;
     emit finished();
 }
 
@@ -260,6 +268,7 @@ void TcpRelay::onLocalTcpSocketReadyRead()
 
     if (stage == STREAM) {
         if (isLocal) {
+            Common::qOut << data.toHex() << endl;
             if (auth) {
                 encryptor->addChunkAuth(data);
             }

--- a/lib/tcprelay.h
+++ b/lib/tcprelay.h
@@ -44,6 +44,7 @@ public:
                       const bool &autoBan,
                       const bool &auth,
                       QObject *parent = 0);
+	~TcpRelay();
 
     enum STAGE { INIT, ADDR, UDP_ASSOC, DNS, CONNECTING, STREAM, DESTROYED };
 


### PR DESCRIPTION
TcpRelay对象在摧毁的时候没有释放动态申请的实例对象.