### PR TITLE
fix linking error

### DIFF
--- a/test/test.pro
+++ b/test/test.pro
@@ -46,7 +46,6 @@ win32: {
     else:            LIBS += -L../lib/debug
 }
 INCLUDEPATH     += $$top_srcdir/../lib
-LIBS            += -L$$top_srcdir/../lib \
-                   -L../lib \
+LIBS            += -L../lib \
                    -lQtShadowsocks \
                    -lbotan-$$BOTAN_VER


### PR DESCRIPTION
solution to [issue79](https://github.com/shadowsocks/libQtShadowsocks/issues/79)

on some platform `.qmake.conf` is not evaluated by default