### PR TITLE
Fix crash on connection finished

### DIFF
--- a/lib/tcpserver.cpp
+++ b/lib/tcpserver.cpp
@@ -91,18 +91,13 @@ void TcpServer::incomingConnection(qintptr socketDescriptor)
     connect(con, &TcpRelay::bytesSend, this, &TcpServer::bytesSend);
     connect(con, &TcpRelay::latencyAvailable,
             this, &TcpServer::latencyAvailable);
-    connect(con, &TcpRelay::finished, this, &TcpServer::onConnectionFinished);
+    connect(con, &TcpRelay::finished, this, [=]() {
+        if (conList.removeOne(con)) {
+            con->deleteLater();
+        }
+    });
     con->moveToThread(threadList.at(workerThreadID++));
     workerThreadID %= totalWorkers;
-}
-
-void TcpServer::onConnectionFinished()
-{
-    TcpRelay *con = qobject_cast<TcpRelay*>(sender());
-    //sometimes the finished signal from TcpRelay gets emitted multiple times
-    if (conList.removeOne(con)) {
-        con->deleteLater();
-    }
 }
 
 bool TcpServer::listen(const QHostAddress &address, quint16 port)

--- a/lib/tcpserver.h
+++ b/lib/tcpserver.h
@@ -69,9 +69,6 @@ private:
     QList<QThread*> threadList;
     quint64 workerThreadID;
     quint64 totalWorkers;
-
-private slots:
-    void onConnectionFinished();
 };
 
 }


### PR DESCRIPTION
Looking into core dumps, `qobject_cast` is causing the crash (not very often, almost randomly).
Changing the slot to a lambda function fixes the issue.