### PR TITLE
modify  lib/cipher.cpp to compile with gcc6 on debian9

### DIFF
--- a/lib/cipher.cpp
+++ b/lib/cipher.cpp
@@ -36,6 +36,7 @@
 #include <QCryptographicHash>
 #include <QMessageAuthenticationCode>
 #include <stdexcept>
+#include <memory>
 
 using namespace QSS;
 
@@ -105,9 +106,11 @@ Cipher::Cipher(const QByteArray &method,
 Cipher::~Cipher()
 {
     if (pipe)   delete pipe;
+#if USE_BOTAN2
     if (kdf)    delete kdf;
     if (msgAuthCode)    delete msgAuthCode;
     if (msgHashFunc)    delete msgHashFunc;
+#endif
 }
 
 const std::map<QByteArray, Cipher::CipherInfo> Cipher::cipherInfoMap = {


### PR DESCRIPTION
to solve:

* lib/cipher.cpp:108:9: error: ‘kdf’ was not declared in this scope
* lib/cipher.cpp:109:9: error: ‘msgAuthCode’ was not declared in this scope
* lib/cipher.cpp:110:9: error: ‘msgHashFunc’ was not declared in this scope
* lib/cipher.cpp:200:9: error: ‘unique_ptr’ is not a member of ‘std’

compiled with gcc6 on debian9