### PR TITLE
Update cipher.cpp

### DIFF
--- a/lib/crypto/cipher.cpp
+++ b/lib/crypto/cipher.cpp
@@ -35,6 +35,7 @@
 #include <botan/hkdf.h>
 #include <botan/hmac.h>
 #include <botan/sha160.h>
+#include <botan/filters.h>
 #endif
 
 #include <QCryptographicHash>


### PR DESCRIPTION
include `<botan/filters.h>` header file, otherwise will get compile error

> libQtShadowsocks/lib/crypto/cipher.cpp:94:25: error: ‘get_cipher’ is not a member of ‘Botan’
         filter = Botan::get_cipher(cipherInfo.internalName, _key, _iv,
